### PR TITLE
Add Flutter demo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+
+# Other files
+.idea/
+.vscode/

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,6 +4,7 @@
 - Added initial documentation files based on the project kickoff conversation.
 - Clarified requirements: one-level quest hierarchy, free map providers, no design assets, MIT license.
 - Created minimal Flutter project with basic quest journal UI and tests.
+- Added a setup script to install Flutter for local development.
 
 
 ## Next Steps

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,10 +2,11 @@
 
 ## Completed
 - Added initial documentation files based on the project kickoff conversation.
-- Clarified requirements: two-level quest hierarchy, free map providers, no design assets, MIT license.
+- Clarified requirements: one-level quest hierarchy, free map providers, no design assets, MIT license.
+- Created minimal Flutter project with basic quest journal UI and tests.
+
 
 ## Next Steps
-- Decide on overall app architecture using Flutter.
-- Experiment with Google Maps and Mapbox for mapping without committing to either.
-- Set up testing framework with Flutter and create initial tests.
-- Implement basic quest model (Quest with Steps) and journal UI.
+- Integrate an interactive map using a free provider.
+- Expand tests and refactor UI code as features grow.
+- Explore on-device AI for quest suggestions.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ QuestLog borrows the vocabulary of RPGs without turning life into a game. The go
 
 We do not yet have design assets or wireframes, so interface decisions rely on best judgement. The code is released under the MIT License.
 
+## Development Setup
+Run `./deps.sh` to install Flutter locally, then use `flutter test` and `flutter run` to build the demo app.
+

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 QuestLog is a mobile application inspired by role-playing games. It blends a journal of quests with an interactive map to help users explore the real world with a sense of adventure.
 
-Quests currently have two levels: a high-level quest with a list of steps beneath it. This keeps things simple while still letting users break goals into meaningful tasks.
+Quests consist of a quest with a list of steps beneath it, keeping the hierarchy simple.
 
 ## MVP Goals
-- **Quest Journal**: Track ongoing and completed quests in a concise format. Support main quests and sub-quests.
+- **Quest Journal**: Track ongoing and completed quests in a concise format. Each quest lists its steps.
 - **Interactive Map**: Display markers for significant locations such as shops, rest points, or user-defined points of interest. Markers link back to quests in the journal.
 - **Navigation and Routing**: Allow quests to include routes and waypoints so users can follow them on the map.
 - **User Customization**: Let users define major and minor locations to keep the map focused and meaningful.

--- a/REQUESTS.md
+++ b/REQUESTS.md
@@ -1,7 +1,7 @@
 # Requests
 
 The following questions have been resolved:
-- Quest hierarchy: start with a two-level structure consisting of a quest and its steps.
+- Quest hierarchy: quests contain one list of steps rather than nested quests.
 - Map services: explore free options like Google Maps or Mapbox; don't commit to a paid provider yet.
 - Design assets: none available, rely on best judgement.
 - Licensing: the repository uses the MIT License.

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Installs Flutter for CI or local development.
+set -euo pipefail
+FLUTTER_VERSION="3.22.0"
+DEST="$HOME/flutter"
+if [ ! -d "$DEST" ]; then
+  mkdir -p "$DEST"
+  curl -L "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" | tar xJ -C "$HOME"
+fi
+export PATH="$DEST/bin:$PATH"
+flutter --version

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ class QuestLogApp extends StatelessWidget {
 class QuestListScreen extends StatelessWidget {
   const QuestListScreen({Key? key}) : super(key: key);
 
-  final List<Quest> quests = const [
+  final List<Quest> quests = [
     Quest('Visit the Temple', [
       QuestStep('Buy tickets'),
       QuestStep('Take the train'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'models/quest.dart';
+
+void main() => runApp(const QuestLogApp());
+
+class QuestLogApp extends StatelessWidget {
+  const QuestLogApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'QuestLog Demo',
+      theme: ThemeData(primarySwatch: Colors.indigo),
+      home: const QuestListScreen(),
+    );
+  }
+}
+
+class QuestListScreen extends StatelessWidget {
+  const QuestListScreen({Key? key}) : super(key: key);
+
+  final List<Quest> quests = const [
+    Quest('Visit the Temple', [
+      QuestStep('Buy tickets'),
+      QuestStep('Take the train'),
+      QuestStep('Explore the grounds'),
+    ]),
+    Quest('Daily Workout', [
+      QuestStep('Warm-up'),
+      QuestStep('Run 5k'),
+      QuestStep('Stretch'),
+    ]),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('QuestLog')),
+      body: ListView(
+        children: quests.map((q) => QuestWidget(quest: q)).toList(),
+      ),
+    );
+  }
+}
+
+class QuestWidget extends StatefulWidget {
+  final Quest quest;
+  const QuestWidget({Key? key, required this.quest}) : super(key: key);
+
+  @override
+  State<QuestWidget> createState() => _QuestWidgetState();
+}
+
+class _QuestWidgetState extends State<QuestWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final quest = widget.quest;
+    return ExpansionTile(
+      title: Text(quest.title),
+      children: quest.steps
+          .map(
+            (s) => CheckboxListTile(
+              title: Text(s.title),
+              value: s.completed,
+              onChanged: (value) {
+                setState(() {
+                  s.completed = value ?? false;
+                });
+              },
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -1,0 +1,13 @@
+class QuestStep {
+  final String title;
+  bool completed;
+
+  const QuestStep(this.title, {this.completed = false});
+}
+
+class Quest {
+  final String title;
+  final List<QuestStep> steps;
+
+  const Quest(this.title, this.steps);
+}

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -2,12 +2,12 @@ class QuestStep {
   final String title;
   bool completed;
 
-  const QuestStep(this.title, {this.completed = false});
+  QuestStep(this.title, {this.completed = false});
 }
 
 class Quest {
   final String title;
   final List<QuestStep> steps;
 
-  const Quest(this.title, this.steps);
+  Quest(this.title, this.steps);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: questlog
+description: A demo QuestLog app.
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:questlog/main.dart';
+
+void main() {
+  testWidgets('Quest list loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const QuestLogApp());
+    expect(find.text('QuestLog'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- initialize Flutter demo with quest and step models
- document simple one-level quest hierarchy
- update plan with progress and next steps
- add minimal tests

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858df7d4cf48326a8d84e25dbab4bad