### PR TITLE
Fix test compilation errors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -8,6 +8,7 @@
 - Updated setup script for Linux and macOS environments.
 - Configured Git to trust the installed Flutter directory to avoid dubious ownership warnings.
 - Pre-caches Flutter artifacts and runs `flutter pub get` so tests pass offline.
+- Fixed compilation errors in `main.dart` so the widget test runs successfully.
 
 
 ## Next Steps

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,13 +11,13 @@ class QuestLogApp extends StatelessWidget {
     return MaterialApp(
       title: 'QuestLog Demo',
       theme: ThemeData(primarySwatch: Colors.indigo),
-      home: const QuestListScreen(),
+      home: QuestListScreen(),
     );
   }
 }
 
 class QuestListScreen extends StatelessWidget {
-  const QuestListScreen({Key? key}) : super(key: key);
+  QuestListScreen({Key? key}) : super(key: key);
 
   final List<Quest> quests = [
     Quest('Visit the Temple', [


### PR DESCRIPTION
## Summary
- update QuestLog app entrypoint to drop `const` usage causing compile errors
- document fix in PLAN

## Testing
- `flutter pub get --offline`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6858e6d6a3848326ba2b5b27f48ed1dd