### PR TITLE
Add map tab and docs for macOS/iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@
 .packages
 .pub/
 build/
+android/
+ios/
+macos/
+windows/
+linux/
+.metadata
+analysis_options.yaml
+pubspec.lock
+*.iml
 
 # Other files
 .idea/

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,9 +9,11 @@
 - Configured Git to trust the installed Flutter directory to avoid dubious ownership warnings.
 - Pre-caches Flutter artifacts and runs `flutter pub get` so tests pass offline.
 - Fixed compilation errors in `main.dart` so the widget test runs successfully.
+- Added a bottom navigation bar with a map tab placeholder.
+- Documented how to run the app on macOS and iPhone.
 
 
 ## Next Steps
-- Integrate an interactive map using a free provider.
+- Connect the placeholder map to a real provider.
 - Expand tests and refactor UI code as features grow.
 - Explore on-device AI for quest suggestions.

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,6 +11,8 @@
 - Fixed compilation errors in `main.dart` so the widget test runs successfully.
 - Added a bottom navigation bar with a map tab placeholder.
 - Documented how to run the app on macOS and iPhone.
+- Documented that `flutter create --platforms=macos,linux,windows .` generates
+  desktop platform folders and added the command to the setup script.
 
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We do not yet have design assets or wireframes, so interface decisions rely on b
 
 ## Development Setup
 Run `source ./deps.sh` on Linux or macOS to install Flutter locally, download artifacts, and fetch Dart packages. The script also configures Git to trust the Flutter directory so `flutter test` works without warnings. After sourcing the script you can run `flutter test` and `flutter run` offline.
+If you want to build for desktop platforms, run `flutter create --platforms=macos,linux,windows .` once to generate the platform directories.
 
 ### Running on macOS
 Use `flutter run -d macos` to launch the desktop build.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ QuestLog is a mobile application inspired by role-playing games. It blends a jou
 Quests consist of a quest with a list of steps beneath it, keeping the hierarchy simple.
 
 ## MVP Goals
-- **Quest Journal**: Track ongoing and completed quests in a concise format. Each quest lists its steps.
-- **Interactive Map**: Display markers for significant locations such as shops, rest points, or user-defined points of interest. Markers link back to quests in the journal.
-- **Navigation and Routing**: Allow quests to include routes and waypoints so users can follow them on the map.
-- **User Customization**: Let users define major and minor locations to keep the map focused and meaningful.
+- **Quest Journal**: Track ongoing and completed quests in a concise format. Each quest lists its steps and you can check them off.
+- **Interactive Map**: A dedicated tab will show an interactive map with markers for quest locations.
+- **Navigation and Routing**: Quests can define routes and waypoints so you can follow them on the map.
+- **User Customization**: Define major and minor locations to keep the map focused and meaningful.
+- **Simple Navigation**: A bottom navigation bar lets you switch between the journal and the map.
 
 ## Future Features
 - **Compass Integration**: Use features like iOS Dynamic Island or Android foreground services for persistent guidance.
@@ -26,4 +27,10 @@ We do not yet have design assets or wireframes, so interface decisions rely on b
 
 ## Development Setup
 Run `source ./deps.sh` on Linux or macOS to install Flutter locally, download artifacts, and fetch Dart packages. The script also configures Git to trust the Flutter directory so `flutter test` works without warnings. After sourcing the script you can run `flutter test` and `flutter run` offline.
+
+### Running on macOS
+Use `flutter run -d macos` to launch the desktop build.
+
+### Running on iPhone
+Connect a device or start the iOS simulator and run `flutter run -d ios`. The first launch may require Xcode to set up signing.
 

--- a/deps.sh
+++ b/deps.sh
@@ -22,4 +22,8 @@ export PATH="$DEST/bin:$PATH"
 git config --global --add safe.directory "$DEST"
 flutter --version
 flutter precache
-(cd "$(dirname "$0")" && flutter pub get)
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ ! -d "$PROJECT_ROOT/macos" ]; then
+  flutter create --platforms=macos,linux,windows "$PROJECT_ROOT"
+fi
+(cd "$PROJECT_ROOT" && flutter pub get)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,38 @@ class QuestLogApp extends StatelessWidget {
     return MaterialApp(
       title: 'QuestLog Demo',
       theme: ThemeData(primarySwatch: Colors.indigo),
-      home: QuestListScreen(),
+      home: const HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _index = 0;
+
+  final List<Widget> _pages = [
+    QuestListScreen(),
+    MapScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Quests'),
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+        ],
+      ),
     );
   }
 }
@@ -70,6 +101,17 @@ class _QuestWidgetState extends State<QuestWidget> {
             ),
           )
           .toList(),
+    );
+  }
+}
+
+class MapScreen extends StatelessWidget {
+  const MapScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Map placeholder'),
     );
   }
 }


### PR DESCRIPTION
## Summary
- show quest journal or map via bottom navigation
- placeholder map screen
- flesh out MVP goals
- document running on macOS and iPhone
- update plan

## Testing
- `flutter pub get --offline`
- `flutter test --no-pub`

------
https://chatgpt.com/codex/tasks/task_e_6858ea6dc4548326b938bf598d58984a