### PR TITLE
Enable quest editing and map markers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -14,6 +14,12 @@
 - Documented how to run the app on macOS and iPhone.
 - Documented that `flutter create --platforms=macos,linux,windows .` generates
   desktop platform folders and added the command to the setup script.
+- Implemented quest editing: users can add, edit, and delete quests and steps.
+- Added ability to choose the active quest and display its steps on the map.
+- Stored quests in a local JSON file for rudimentary persistence.
+- Rendered map markers for quest steps using Leaflet inside the WebView.
+- Handled unsupported platforms by showing a placeholder when WebView isn't available.
+- Configured the WebView platform on macOS and iOS so the map loads correctly.
 
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ QuestLog is a mobile application inspired by role-playing games. It blends a jou
 Quests consist of a quest with a list of steps beneath it, keeping the hierarchy simple.
 
 ## MVP Goals
-- **Quest Journal**: Track ongoing and completed quests in a concise format. Each quest lists its steps and you can check them off.
-- **Interactive Map**: A dedicated tab will show an interactive map with markers for quest locations.
+ - **Quest Journal**: Create quests, edit their steps, and check them off. All quests persist locally in a JSON file.
+ - **Interactive Map**: A dedicated tab will show an interactive map with markers for quest locations. On unsupported platforms a placeholder message is shown.
 - **Navigation and Routing**: Quests can define routes and waypoints so you can follow them on the map.
 - **User Customization**: Define major and minor locations to keep the map focused and meaningful.
 - **Simple Navigation**: A bottom navigation bar lets you switch between the journal and the map.
@@ -18,7 +18,8 @@ Quests consist of a quest with a list of steps beneath it, keeping the hierarchy
 - **Optional Objectives**: Support optional or side quests to make journeys feel layered without adding competitive gamification.
 
 ## Tech Stack
-QuestLog will be built with **Flutter** so the same codebase runs on both iOS and Android. The interactive map currently loads OpenStreetMap in a WebView using the `webview_flutter` package. The app relies on free services and may integrate with on-device AI models or online services such as OpenAI if needed.
+QuestLog will be built with **Flutter** so the same codebase runs on both iOS and Android. The interactive map currently loads OpenStreetMap in a WebView using the `webview_flutter` package. This map works on Android, iOS, and macOS; other platforms show a placeholder.
+On macOS the app sets `WebViewPlatform.instance` to `WebKitWebViewPlatform()` from `webview_flutter_wkwebview` so the map renders correctly. The app relies on free services and may integrate with on-device AI models or online services such as OpenAI if needed.
 
 ## Philosophy
 QuestLog borrows the vocabulary of RPGs without turning life into a game. The goal is to encourage daily adventure and progress in real life, not to chase points or achievements.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
-import 'models/quest.dart';
+import 'dart:convert';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
+import 'package:flutter/foundation.dart';
+import 'dart:io';
+import 'models/quest.dart';
+import 'quest_editor.dart';
+import 'storage.dart';
 
-void main() => runApp(const QuestLogApp());
+void main() {
+  if (!kIsWeb && (Platform.isMacOS || Platform.isIOS)) {
+    WebViewPlatform.instance = WebKitWebViewPlatform();
+  }
+  runApp(const QuestLogApp());
+}
 
 class QuestLogApp extends StatelessWidget {
   const QuestLogApp({Key? key}) : super(key: key);
@@ -26,13 +37,96 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   int _index = 0;
+  final _storage = QuestStorage();
+  List<Quest> _quests = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final loaded = await _storage.load();
+    if (loaded.isEmpty) {
+      loaded.addAll([
+        Quest('Visit the Temple', [
+          QuestStep('Buy tickets', latitude: 35.0, longitude: -120.0),
+          QuestStep('Take the train'),
+          QuestStep('Explore the grounds', latitude: 35.1, longitude: -120.1),
+        ]),
+        Quest('Daily Workout', [
+          QuestStep('Warm-up'),
+          QuestStep('Run 5k'),
+          QuestStep('Stretch'),
+        ]),
+      ]);
+    }
+    setState(() {
+      _quests = loaded;
+    });
+  }
+
+  Future<void> _save() async => _storage.save(_quests);
+
+  Quest? get _activeQuest {
+    for (final q in _quests) {
+      if (q.active) return q;
+    }
+    return null;
+  }
+
+  void _setActive(Quest quest) {
+    setState(() {
+      for (final q in _quests) {
+        q.active = q == quest;
+      }
+    });
+    _save();
+  }
+
+  Future<void> _addQuest() async {
+    final quest = await Navigator.of(context)
+        .push<Quest>(MaterialPageRoute(builder: (_) => const QuestEditor()));
+    if (quest != null) {
+      setState(() {
+        _quests.add(quest);
+      });
+      _save();
+    }
+  }
+
+  Future<void> _editQuest(int index) async {
+    final quest = _quests[index];
+    final updated = await Navigator.of(context).push<Quest>(
+        MaterialPageRoute(builder: (_) => QuestEditor(quest: quest)));
+    if (updated != null) {
+      setState(() {
+        _quests[index] = updated;
+      });
+      _save();
+    }
+  }
+
+  void _deleteQuest(int index) {
+    setState(() {
+      _quests.removeAt(index);
+    });
+    _save();
+  }
 
   Widget _pageForIndex(int index) {
     switch (index) {
       case 0:
-        return QuestListScreen();
+        return QuestListScreen(
+          quests: _quests,
+          onAdd: _addQuest,
+          onEdit: _editQuest,
+          onDelete: _deleteQuest,
+          onSetActive: _setActive,
+        );
       case 1:
-        return const MapScreen();
+        return MapScreen(activeQuest: _activeQuest);
       default:
         return Container();
     }
@@ -55,27 +149,41 @@ class _HomeScreenState extends State<HomeScreen> {
 }
 
 class QuestListScreen extends StatelessWidget {
-  QuestListScreen({Key? key}) : super(key: key);
+  final List<Quest> quests;
+  final VoidCallback onAdd;
+  final void Function(int) onEdit;
+  final void Function(int) onDelete;
+  final void Function(Quest) onSetActive;
 
-  final List<Quest> quests = [
-    Quest('Visit the Temple', [
-      QuestStep('Buy tickets'),
-      QuestStep('Take the train'),
-      QuestStep('Explore the grounds'),
-    ]),
-    Quest('Daily Workout', [
-      QuestStep('Warm-up'),
-      QuestStep('Run 5k'),
-      QuestStep('Stretch'),
-    ]),
-  ];
+  const QuestListScreen({
+    Key? key,
+    required this.quests,
+    required this.onAdd,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onSetActive,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('QuestLog')),
-      body: ListView(
-        children: quests.map((q) => QuestWidget(quest: q)).toList(),
+      appBar: AppBar(
+        title: const Text('QuestLog'),
+        actions: [
+          IconButton(onPressed: onAdd, icon: const Icon(Icons.add)),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: quests.length,
+        itemBuilder: (context, index) {
+          final quest = quests[index];
+          return QuestWidget(
+            quest: quest,
+            onEdit: () => onEdit(index),
+            onDelete: () => onDelete(index),
+            onSetActive: () => onSetActive(quest),
+          );
+        },
       ),
     );
   }
@@ -83,7 +191,16 @@ class QuestListScreen extends StatelessWidget {
 
 class QuestWidget extends StatefulWidget {
   final Quest quest;
-  const QuestWidget({Key? key, required this.quest}) : super(key: key);
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onSetActive;
+  const QuestWidget({
+    Key? key,
+    required this.quest,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onSetActive,
+  }) : super(key: key);
 
   @override
   State<QuestWidget> createState() => _QuestWidgetState();
@@ -94,7 +211,18 @@ class _QuestWidgetState extends State<QuestWidget> {
   Widget build(BuildContext context) {
     final quest = widget.quest;
     return ExpansionTile(
-      title: Text(quest.title),
+      title: Row(
+        children: [
+          Expanded(child: Text(quest.title)),
+          IconButton(icon: const Icon(Icons.edit), onPressed: widget.onEdit),
+          IconButton(
+              icon: const Icon(Icons.delete), onPressed: widget.onDelete),
+          IconButton(
+            icon: Icon(quest.active ? Icons.star : Icons.star_border),
+            onPressed: widget.onSetActive,
+          ),
+        ],
+      ),
       children: quest.steps
           .map(
             (s) => CheckboxListTile(
@@ -113,27 +241,83 @@ class _QuestWidgetState extends State<QuestWidget> {
 }
 
 class MapScreen extends StatefulWidget {
-  const MapScreen({Key? key}) : super(key: key);
+  final Quest? activeQuest;
+  const MapScreen({Key? key, this.activeQuest}) : super(key: key);
 
   @override
   State<MapScreen> createState() => _MapScreenState();
 }
 
 class _MapScreenState extends State<MapScreen> {
-  late final WebViewController _controller;
+  WebViewController? _controller;
+  bool get _available =>
+      !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS);
+
+  String _htmlForQuest(Quest quest) {
+    final stepsWithLoc =
+        quest.steps.where((s) => s.latitude != null && s.longitude != null);
+    final first = stepsWithLoc.isNotEmpty ? stepsWithLoc.first : null;
+    final markers = stepsWithLoc
+        .map((s) =>
+            "L.marker([${s.latitude},${s.longitude}]).addTo(map).bindPopup(${jsonEncode(s.title)});")
+        .join();
+    final centerLat = first?.latitude ?? 0;
+    final centerLng = first?.longitude ?? 0;
+    return '''
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body style="margin:0">
+  <div id="map" style="height:100vh;"></div>
+  <script>
+    var map = L.map('map').setView([$centerLat, $centerLng], 13);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors'
+    }).addTo(map);
+    $markers
+  </script>
+</body>
+</html>
+''';
+  }
 
   @override
   void initState() {
     super.initState();
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..loadRequest(Uri.parse('https://www.openstreetmap.org'));
+    if (_available) {
+      _controller = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted);
+      if (widget.activeQuest != null) {
+        _controller!.loadHtmlString(_htmlForQuest(widget.activeQuest!));
+      } else {
+        _controller!.loadRequest(Uri.parse('https://www.openstreetmap.org'));
+      }
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MapScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_available &&
+        widget.activeQuest != oldWidget.activeQuest &&
+        widget.activeQuest != null) {
+      _controller!.loadHtmlString(_htmlForQuest(widget.activeQuest!));
+    }
   }
 
   @override
   Widget build(BuildContext context) {
+    if (!_available) {
+      return const Scaffold(
+        body: Center(child: Text('Map view not supported on this platform')),
+      );
+    }
     return Scaffold(
-      body: WebViewWidget(controller: _controller),
+      body: WebViewWidget(controller: _controller!),
     );
   }
 }

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -1,13 +1,47 @@
-class QuestStep {
-  final String title;
-  bool completed;
+import 'dart:convert';
 
-  QuestStep(this.title, {this.completed = false});
+class QuestStep {
+  String title;
+  bool completed;
+  double? latitude;
+  double? longitude;
+
+  QuestStep(this.title,
+      {this.completed = false, this.latitude, this.longitude});
+
+  QuestStep.fromJson(Map<String, dynamic> json)
+      : title = json['title'],
+        completed = json['completed'] ?? false,
+        latitude = (json['latitude'] as num?)?.toDouble(),
+        longitude = (json['longitude'] as num?)?.toDouble();
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'completed': completed,
+        if (latitude != null) 'latitude': latitude,
+        if (longitude != null) 'longitude': longitude,
+      };
 }
 
 class Quest {
-  final String title;
-  final List<QuestStep> steps;
+  String title;
+  List<QuestStep> steps;
+  bool active;
 
-  Quest(this.title, this.steps);
+  Quest(this.title, this.steps, {this.active = false});
+
+  Quest.fromJson(Map<String, dynamic> json)
+      : title = json['title'],
+        active = json['active'] ?? false,
+        steps =
+            (json['steps'] as List).map((e) => QuestStep.fromJson(e)).toList();
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'active': active,
+        'steps': steps.map((e) => e.toJson()).toList(),
+      };
+
+  @override
+  String toString() => jsonEncode(toJson());
 }

--- a/lib/quest_editor.dart
+++ b/lib/quest_editor.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'models/quest.dart';
+
+class QuestEditor extends StatefulWidget {
+  final Quest? quest;
+  const QuestEditor({super.key, this.quest});
+
+  @override
+  State<QuestEditor> createState() => _QuestEditorState();
+}
+
+class _QuestEditorState extends State<QuestEditor> {
+  late TextEditingController _title;
+  late List<QuestStep> _steps;
+
+  @override
+  void initState() {
+    super.initState();
+    _title = TextEditingController(text: widget.quest?.title ?? '');
+    _steps = widget.quest != null
+        ? widget.quest!.steps
+            .map((s) => QuestStep(s.title, completed: s.completed))
+            .toList()
+        : [];
+  }
+
+  void _addStep() {
+    setState(() {
+      _steps.add(QuestStep(''));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.quest == null ? 'New Quest' : 'Edit Quest'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(
+                Quest(_title.text, _steps),
+              );
+            },
+            child: const Text('Save', style: TextStyle(color: Colors.white)),
+          )
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _title,
+              decoration: const InputDecoration(labelText: 'Quest Title'),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: _steps.length,
+                itemBuilder: (context, index) {
+                  final step = _steps[index];
+                  return ListTile(
+                    title: TextField(
+                      controller: TextEditingController(text: step.title)
+                        ..selection =
+                            TextSelection.collapsed(offset: step.title.length),
+                      onChanged: (val) => step.title = val,
+                      decoration:
+                          InputDecoration(labelText: 'Step ${index + 1}'),
+                    ),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() {
+                          _steps.removeAt(index);
+                        });
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _addStep,
+              child: const Text('Add Step'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'models/quest.dart';
+
+class QuestStorage {
+  final String fileName;
+  QuestStorage({this.fileName = 'quests.json'});
+
+  Future<File> _file() async {
+    final directory = Directory.current;
+    return File('${directory.path}/$fileName');
+  }
+
+  Future<List<Quest>> load() async {
+    final f = await _file();
+    if (!await f.exists()) return [];
+    final data = jsonDecode(await f.readAsString()) as List<dynamic>;
+    return data.map((e) => Quest.fromJson(e)).toList();
+  }
+
+  Future<void> save(List<Quest> quests) async {
+    final f = await _file();
+    await f.writeAsString(jsonEncode(quests.map((e) => e.toJson()).toList()));
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   webview_flutter: ^4.7.0
+  webview_flutter_wkwebview: ^3.14.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow players to add, edit, and delete quests with a new quest editor
- save quests to a JSON file so they persist across launches
- choose an active quest and display its steps on the map
- show quest step markers with Leaflet inside the WebView
- handle platforms without WebView support by showing a placeholder
- fix map on macOS by registering the WebKitWebView platform

## Testing
- `dart format lib`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6858f1bc311c8326a9b4516b48ab32f4