### PR TITLE
Refactor QuestListView and improve setup check

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -28,6 +28,8 @@
 - **Updated documentation**: README explains running the SwiftUI app and no longer references the previous approach.
 - Renamed package and files to drop the "SwiftUI" suffix and simplified the quest list to compile cleanly.
 - Added a helper script (`deps.sh`) to verify a Swift toolchain is available.
+- Refactored `QuestListView` into smaller functions so the Swift compiler can type-check it.
+- Improved `deps.sh` with checks for Xcode on macOS.
 
 ## Next Steps
 - Expand tests and refactor UI code as features grow.

--- a/QuestLog/QuestListView.swift
+++ b/QuestLog/QuestListView.swift
@@ -8,23 +8,7 @@ struct QuestListView: View {
     var body: some View {
         NavigationView {
             List {
-                ForEach(store.quests.indices, id: .self) { index in
-                    let quest = store.quests[index]
-                    Section(header: header(for: quest, index: index)) {
-                        ForEach(quest.steps.indices, id: .self) { stepIndex in
-                            let step = quest.steps[stepIndex]
-                            Toggle(step.name, isOn: stepBinding(stepIndex, index))
-                        }
-                        .onDelete { offsets in
-                            store.quests[index].steps.remove(atOffsets: offsets)
-                            store.save()
-                        }
-                    }
-                }
-                .onDelete { indices in
-                    store.quests.remove(atOffsets: indices)
-                    store.save()
-                }
+                questSections
             }
             .navigationTitle("Quests")
             .toolbar {
@@ -41,6 +25,32 @@ struct QuestListView: View {
                     }
                     store.save()
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var questSections: some View {
+        ForEach(store.quests.indices, id: .self) { index in
+            section(for: index)
+        }
+        .onDelete { indices in
+            store.quests.remove(atOffsets: indices)
+            store.save()
+        }
+    }
+
+    @ViewBuilder
+    private func section(for index: Int) -> some View {
+        let quest = store.quests[index]
+        Section(header: header(for: quest, index: index)) {
+            ForEach(quest.steps.indices, id: .self) { stepIndex in
+                let step = quest.steps[stepIndex]
+                Toggle(step.name, isOn: stepBinding(stepIndex, index))
+            }
+            .onDelete { offsets in
+                store.quests[index].steps.remove(atOffsets: offsets)
+                store.save()
             }
         }
     }

--- a/deps.sh
+++ b/deps.sh
@@ -7,4 +7,14 @@ if ! command -v swift >/dev/null; then
   exit 1
 fi
 
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "SwiftUI apps require macOS with Xcode. Running on $(uname)." >&2
+else
+  if ! command -v xcodebuild >/dev/null; then
+    echo "Xcode not found. Install from the Mac App Store." >&2
+    exit 1
+  fi
+  xcodebuild -version | head -n 1
+fi
+
 swift --version


### PR DESCRIPTION
## Summary
- refactor QuestListView into smaller functions so Swift can type‑check it
- add Xcode checks in deps.sh and warn when not on macOS
- record the changes in PLAN

## Testing
- `./deps.sh`
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68590aa73c488326bde30f30bdb89732